### PR TITLE
Mobile friendly menu layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,6 +18,12 @@
   overflow-y: auto;
 }
 
+@media screen and (max-width: 800px) {
+  .main > *:not(.home) {
+    padding: 5% 5vw;
+  }
+}
+
 a {
   text-decoration: none;
   color: #000;

--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -21,6 +21,12 @@
   margin: 0 10px;
 }
 
+@media screen and (max-width: 800px) {
+  .banner .message {
+    font-size: 0.8em;
+  }
+}
+
 .banner.dismissed {
   display: none;
 }

--- a/src/components/Menu/Menu.css
+++ b/src/components/Menu/Menu.css
@@ -4,9 +4,8 @@
 
 .menu table {
   width: 100%;
-  min-width: 500px;
   font-size: 1.2em;
-  margin: 30px 0;
+  margin: 30px 0 0 0;
 }
 
 .menu h1 {
@@ -31,13 +30,12 @@
 }
 
 .menu .slider-container {
-  position: absolute;
   margin: auto;
   top: 5%;
   bottom: 76%;
   left: 0;
   right: 0;
-  padding: 1rem 25%;
+  height: 15vh;
   display: flex;
   flex-direction: row;
 }
@@ -54,10 +52,11 @@
 .menu .slider {
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(15, minmax(200px, 1fr));
+  grid-template-columns: repeat(15, minmax(240px, 1fr));
   overflow: scroll;
   height: 100%;
   scrollbar-width: none;
+  font-size: 1.2em;
 }
 
 .menu .slider::-webkit-scrollbar {
@@ -71,20 +70,15 @@
   align-items: center;
   cursor: pointer;
   color: white;
-  font-weight: 900;
 }
 
 .menu .active-category {
-  position: absolute;
-  margin: auto 30%;
-  top: 25%;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  margin: auto 8%;
 }
 
 .menu tr td.number {
   width: 50px;
+  padding-top: 0;
 }
 
 .menu tr td.name {
@@ -93,4 +87,23 @@
 
 .menu tr td.price {
   text-align: right;
+}
+
+@media screen and (max-width: 800px) {
+  .menu table {
+    font-size: 0.8rem;
+  }
+  .menu .slider-container .left,
+  .menu .slider-container .right {
+    display: none;
+  }
+  .menu tr td.number {
+    width: 30px;
+  }
+  .menu .active-category {
+    margin: 0;
+  }
+  .menu .description {
+    font-size: 0.75em;
+  }
 }

--- a/src/components/Menu/takeout-menu.json
+++ b/src/components/Menu/takeout-menu.json
@@ -1,5 +1,5 @@
 {
-  "delivery": "Free Delivery with orders over $35.00 and within 3km radius",
+  "delivery": "Free Delivery with orders over $35 and within 3km radius",
   "discounts": [
     "10% off cash pick-up orders",
     "5% off credit/debit card pick-up orders",


### PR DESCRIPTION
![CFDE8C47-4736-45BB-B75C-1C29D13A9F7E_1_201_a](https://user-images.githubusercontent.com/16008563/83344771-895db480-a2c8-11ea-95e6-9c2508846118.jpeg)

Adjusting the margins and table width on smaller screens so that the whole menu is visible horizontally. The slider left and right chevron buttons are also hidden in favour of finger scrolling.